### PR TITLE
cleanup WorkoutLists, Run and Workout

### DIFF
--- a/src/main/java/constants/ErrorConstant.java
+++ b/src/main/java/constants/ErrorConstant.java
@@ -22,6 +22,9 @@ public class ErrorConstant {
     // General Errors
     public static final String NEGATIVE_VALUE_ERROR = "Requires a positive integer!";
     public static final String INVALID_INDEX_DELETE_ERROR = "Invalid index to delete!";
+    public static final String INVALID_INDEX_BOUND_ERROR = "Index is Out of Bounds";
+
+    public static final String INVALID_INDEX_ERROR = "Index must be a valid positive integer.";
 
 
     // Storage Errors
@@ -66,7 +69,6 @@ public class ErrorConstant {
             "Example input: /item:item /index:index"
             + System.lineSeparator()
             + "Only input what is required! Additional characters between flags will cause errors.";
-    public static final String INVALID_INDEX_ERROR = "Index must be a valid positive integer.";
 
     // EXERCISE ERRORS
 

--- a/src/main/java/constants/WorkoutConstant.java
+++ b/src/main/java/constants/WorkoutConstant.java
@@ -17,7 +17,12 @@ public class WorkoutConstant {
     public static final String REPS_FLAG = "/r:";
     public static final String WEIGHTS_FLAG = "/w:";
 
+    public static final String COLON = ":";
     // Integers
+    public static final int RUN_TIME_FIRST_PART = 0;
+    public static final int RUN_TIME_SECOND_PART = 1;
+    public static final int RUN_TIME_THIRD_PART = 2;
+
     public static final int NUMBER_OF_RUN_PARAMETERS = 3;
     public static final int NUMBER_OF_GYM_PARAMETERS = 2;
     public static final int NUMBER_OF_GYM_STATION_PARAMETERS = 4;
@@ -71,10 +76,10 @@ public class WorkoutConstant {
 
     // HISTORY (ALL WORKOUTS) CONSTANTS
     public static final String HISTORY_WORKOUTS_HEADER = "Showing all workouts (runs and gyms):";
-    public static final String HISTORY_WORKOUTS_DATA_FORMAT = "%-5s\t%-12s\t%-25s\t%-15s\t%-8s";
+    public static final String HISTORY_WORKOUTS_DATA_FORMAT = "%-5s\t%-12s\t%-25s\t%-20s\t%-8s";
     public static final String HISTORY_WORKOUTS_HEADER_FORMAT = String.format(
-            "%-6s\t%-5s\t%-12s\t%-25s\t%-15s\t%-8s", "Index",
-            "Type", "Date", "Distance (km) / Station", "Duration / Sets", "Pace (min/km)");
+            "%-6s\t%-5s\t%-12s\t%-25s\t%-20s\t%-8s", "Index",
+            "Type", "Date", "[Distance (km) / Station]", "[Duration / Sets]", "Pace (min/km)");
     public static final String HISTORY_WORKOUTS_DATA_HEADER_FORMAT = "%-6s\t%s";
 
     // Formatted Strings/Messages
@@ -94,6 +99,14 @@ public class WorkoutConstant {
     public static final String ADD_GYM = "Successfully added a new gym session";
     public static final String STATION_GYM_FORMAT = "e.g. Bench Press /s:2 /r:4 " +
             "/w:10,20";
+
+    public static final String TIME_WITH_HOURS_FORMAT = TWO_DIGIT_PLACE_FORMAT
+            + COLON + TWO_DIGIT_PLACE_FORMAT
+            + COLON + TWO_DIGIT_PLACE_FORMAT;
+    public static final String TIME_WITHOUT_HOURS_FORMAT = TWO_DIGIT_PLACE_FORMAT
+            + COLON + TWO_DIGIT_PLACE_FORMAT;
+
+    public static final String RUN_PACE_FORMAT = "%d:%02d/km";
     public static final String INVALID_RUN_TIME = "Invalid run time!";
     public static final String INVALID_GYM_INPUT = "Invalid gym parameters!";
     public static final String INVALID_GYM_STATION_INDEX = "Invalid gym station index!";

--- a/src/main/java/constants/WorkoutConstant.java
+++ b/src/main/java/constants/WorkoutConstant.java
@@ -80,12 +80,14 @@ public class WorkoutConstant {
     // Formatted Strings/Messages
     public static final String RUN_DATA_FORMAT = "%-6s\t%-10s\t%-10s\t%-10s\t%-12s";
     public static final String RUN_DATA_INDEX_FORMAT = "%-6d\t%-6s";
-
     public static final String RUN_HEADER_INDEX_FORMAT = String.format("%-6s\t%-6s\t%-10s\t%-10s\t%-10s\t%-12s",
             "Index", "Type", "Time", "Distance", "Pace", "Date");
+    public static final String RUN_DELETE_MESSAGE_FORMAT = "Removed Run entry with %s km at %s.";
     public static final String GYM_STATION_FORMAT = "%s: ";
     public static final String GYM_SET_FORMAT = "%d reps at %.3f KG";
     public static final String GYM_SET_INDEX_FORMAT = "\t- Set %d. %s";
+    public static final String GYM_DELETE_MESSAGE_FORMAT = "Removed Gym entry with %d stations.";
+
     public static final String INDIVIDUAL_GYM_STATION_FORMAT = "%d sets";
     public static final String RUN_HEADER = "Type\tTime\t\tDistance\tPace\t\tDate";
     public static final String ADD_RUN = "Successfully added a new run session";

--- a/src/main/java/storage/DataFile.java
+++ b/src/main/java/storage/DataFile.java
@@ -480,14 +480,13 @@ public class DataFile {
     public void writeWorkoutData(FileWriter dataFile,
                                  ArrayList<Workout> workoutArrayList) throws IOException {
 
-        Parser newParser = new Parser();
         // Write each run entry in a specific format
         // run format: run:DISTANCE:TIME:DATE
         if (!workoutArrayList.isEmpty()) {
             for (Workout workoutEntry : workoutArrayList) {
                 if (workoutEntry instanceof Run) {
                     Run runEntry = (Run) workoutEntry;
-                    String formattedDate = newParser.parseFormattedDate(runEntry.getDate());
+                    String formattedDate = runEntry.getDateForFile();
                     String formattedTime = runEntry.getTimes().replace(":", ".");
 
                     dataFile.write(DataType.RUN + UiConstant.SPLIT_BY_COLON + runEntry.getDistance() +

--- a/src/main/java/ui/Handler.java
+++ b/src/main/java/ui/Handler.java
@@ -14,7 +14,7 @@ import utility.Filters.HealthFilters;
 import utility.Parser;
 import utility.Filters.WorkoutFilters;
 import utility.Validation;
-import workouts.WorkoutList;
+import workouts.WorkoutLists;
 
 import java.util.Scanner;
 import storage.LogFile;
@@ -178,11 +178,11 @@ public class Handler {
                 break;
 
             case GYM:
-                WorkoutList.deleteGym(index);
+                WorkoutLists.deleteGym(index);
                 break;
 
             case RUN:
-                WorkoutList.deleteRun(index);
+                WorkoutLists.deleteRun(index);
                 break;
 
             case APPOINTMENT:
@@ -316,7 +316,7 @@ public class Handler {
 
 
             dataFile.saveDataFile(DataFile.userName, HealthList.getBmis(), HealthList.getAppointments(),
-                    HealthList.getPeriods(), WorkoutList.getWorkouts());
+                    HealthList.getPeriods(), WorkoutLists.getWorkouts());
             LogFile.writeLog("File saved", false);
         } catch (CustomExceptions.FileWriteError e) {
             LogFile.writeLog("File write error", true);

--- a/src/main/java/ui/Handler.java
+++ b/src/main/java/ui/Handler.java
@@ -1,7 +1,10 @@
 //@@author L5-Z
 package ui;
 
+import health.Appointment;
+import health.Bmi;
 import health.HealthList;
+import health.Period;
 import storage.DataFile;
 import utility.CustomExceptions;
 import constants.ErrorConstant;
@@ -14,8 +17,10 @@ import utility.Filters.HealthFilters;
 import utility.Parser;
 import utility.Filters.WorkoutFilters;
 import utility.Validation;
+import workouts.Workout;
 import workouts.WorkoutLists;
 
+import java.util.ArrayList;
 import java.util.Scanner;
 import storage.LogFile;
 
@@ -311,17 +316,22 @@ public class Handler {
      */
     public void terminateBot() {
         LogFile.writeLog("User terminating PulsePilot", false);
+
         try {
             LogFile.writeLog("Attempting to save data file", false);
 
+            String userName = DataFile.userName; // need to make it non static
+            ArrayList<Workout> workoutList = WorkoutLists.getWorkouts();
+            ArrayList<Bmi> bmiList = HealthList.getBmis();
+            ArrayList<Appointment> appointmentList = HealthList.getAppointments();
+            ArrayList<Period> periodList = HealthList.getPeriods();
+            dataFile.saveDataFile(userName, bmiList, appointmentList, periodList, workoutList);
 
-            dataFile.saveDataFile(DataFile.userName, HealthList.getBmis(), HealthList.getAppointments(),
-                    HealthList.getPeriods(), WorkoutLists.getWorkouts());
-            LogFile.writeLog("File saved", false);
         } catch (CustomExceptions.FileWriteError e) {
             LogFile.writeLog("File write error", true);
             output.printException(e.getMessage());
         }
+
         output.printGoodbyeMessage();
         // Yet to implement : Reply.printReply("Saved tasks as: " + Constant.FILE_NAME);
         LogFile.writeLog("Bot exited gracefully", false);

--- a/src/main/java/ui/Output.java
+++ b/src/main/java/ui/Output.java
@@ -86,11 +86,10 @@ public class Output {
      * Returns the formatted string for printing runs.
      *
      * @param index          The index of the run.
-     * @param currentWorkout The current Workout object within the list.
      * @return A string
      */
-    private String getFormattedRunWithIndex(int index, Workout currentWorkout) {
-        return String.format(WorkoutConstant.RUN_DATA_INDEX_FORMAT, index, currentWorkout);
+    private String getFormattedRunWithIndex(int index, Run currentRun) {
+        return String.format(WorkoutConstant.RUN_DATA_INDEX_FORMAT, index, currentRun);
     }
 
     /**
@@ -184,6 +183,7 @@ public class Output {
         printLine();
     }
 
+
     /**
      * Prints all Workout objects (Run and Gym) based on the time it was added.
      * The list is sorted in descending order. (Latest one first)
@@ -196,29 +196,36 @@ public class Output {
         System.out.println(WorkoutConstant.HISTORY_WORKOUTS_HEADER);
         System.out.println(WorkoutConstant.HISTORY_WORKOUTS_HEADER_FORMAT);
 
-        ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts(WorkoutConstant.ALL);
-        for (int i = 0; i < workoutList.size(); i++) {
-            Workout workout = workoutList.get(i);
-            if (workout instanceof Run) {
-                Run run = (Run) workout;
-                System.out.printf((WorkoutConstant.HISTORY_WORKOUTS_DATA_HEADER_FORMAT) + "%n",
-                        (i + 1), run.getFormatForAllHistory());
-            } else {
-                Gym gym = (Gym) workout;
-                int numberOfStation = gym.getStations().size();
-                for (int j = 0; j < numberOfStation; j++) {
-                    String gymString;
-                    if (j == 0) {
-                        gymString = String.format(WorkoutConstant.HISTORY_WORKOUTS_DATA_HEADER_FORMAT,
-                                (i + 1), gym.getHistoryFormatForSpecificGymStation(j));
-                    } else {
-                        gymString = String.format(WorkoutConstant.HISTORY_WORKOUTS_DATA_HEADER_FORMAT,
-                                "", gym.getHistoryFormatForSpecificGymStation(j));
+        ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts();
+        if (workoutList.isEmpty()) {
+            printWorkoutEmptyMessage();
+        }
+        else {
+            for (int i = 0; i < workoutList.size(); i++) {
+                Workout workout = workoutList.get(i);
+                if (workout instanceof Run) {
+                    Run run = (Run) workout;
+                    String formattedRunString = run.getFormatForAllHistory();
+                    System.out.printf((WorkoutConstant.HISTORY_WORKOUTS_DATA_HEADER_FORMAT) + "%n",
+                            (i + 1), formattedRunString);
+                } else {
+                    Gym gym = (Gym) workout;
+                    int numberOfStation = gym.getStations().size();
+                    for (int j = 0; j < numberOfStation; j++) {
+                        String gymString;
+                        if (j == 0) {
+                            gymString = String.format(WorkoutConstant.HISTORY_WORKOUTS_DATA_HEADER_FORMAT,
+                                    (i + 1), gym.getHistoryFormatForSpecificGymStation(j));
+                        } else {
+                            gymString = String.format(WorkoutConstant.HISTORY_WORKOUTS_DATA_HEADER_FORMAT,
+                                    "", gym.getHistoryFormatForSpecificGymStation(j));
+                        }
+                        System.out.println(gymString);
                     }
-                    System.out.println(gymString);
                 }
             }
         }
+
         printLine();
     }
 
@@ -231,16 +238,22 @@ public class Output {
     protected void printRunHistory() throws CustomExceptions.OutOfBounds, CustomExceptions.InvalidInput {
         printLine();
         System.out.println("Your run history:");
-        ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts(WorkoutConstant.RUN);
-        String runHeader = String.format(WorkoutConstant.RUN_HEADER_INDEX_FORMAT);
-        System.out.println(runHeader);
+        ArrayList<Run> runList = WorkoutLists.getRuns();
 
-        for (int i = 0; i < workoutList.size(); i++) {
-            int index = i + 1;
-            Workout currentWorkout = workoutList.get(i);
-            String output = getFormattedRunWithIndex(index, currentWorkout);
-            System.out.println(output);
+        if(runList.isEmpty()){
+            printRunEmptyMessage();
+        } else {
+            String runHeader = String.format(WorkoutConstant.RUN_HEADER_INDEX_FORMAT);
+            System.out.println(runHeader);
+
+            for (int i = 0; i < runList.size(); i++) {
+                int index = i + 1;
+                Run currentRun = runList.get(i);
+                String output = getFormattedRunWithIndex(index, currentRun);
+                System.out.println(output);
+            }
         }
+
         printLine();
     }
 
@@ -256,24 +269,46 @@ public class Output {
         }
     }
 
+
+    private void printGymList(ArrayList<Gym> gymList){
+        for (int i = 0; i < gymList.size(); i++) {
+            int index = i + 1;
+            Gym currentWorkout = gymList.get(i);
+            System.out.println("Gym Session " + index + currentWorkout);
+            printGymStats(currentWorkout);
+            if (i != gymList.size() - 1) {
+                printLine();
+            }
+        }
+    }
+
+    /**
+     * Prints a message when the Gym list is empty.
+     */
+
+    private void printGymEmptyMessage(){
+        printException(ErrorConstant.GYM_EMPTY_ERROR);
+    }
+
+    private void printRunEmptyMessage(){
+        printException(ErrorConstant.RUN_EMPTY_ERROR);
+    }
+
+    private void printWorkoutEmptyMessage(){
+        printException(ErrorConstant.WORKOUTS_EMPTY_ERROR);
+    }
     /**
      * Prints all the information for all Gym objects within the list.
      *
-     * @throws CustomExceptions.OutOfBounds  If index is out of bounds.
-     * @throws CustomExceptions.InvalidInput If user input is invalid.
      */
-    protected void printGymHistory() throws CustomExceptions.OutOfBounds, CustomExceptions.InvalidInput {
+    protected void printGymHistory() {
         printLine();
         System.out.println("Your gym history:");
-        ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts(WorkoutConstant.GYM);
-        for (int i = 0; i < workoutList.size(); i++) {
-            int index = i + 1;
-            Gym currentWorkout = (Gym) workoutList.get(i);
-            System.out.println("Gym Session " + index + currentWorkout);
-            printGymStats(currentWorkout);
-            if (i != workoutList.size() - 1) {
-                printLine();
-            }
+        ArrayList<Gym> gymList = WorkoutLists.getGyms();
+        if (gymList.isEmpty()) {
+            printGymEmptyMessage();
+        } else {
+            printGymList(gymList);
         }
         printLine();
     }
@@ -342,7 +377,7 @@ public class Output {
 
         try {
             printLine();
-            Workout latestRun = WorkoutLists.getLatestRun();
+            Run latestRun = WorkoutLists.getLatestRun();
             String latestRunString = getFormattedRunWithIndex(WorkoutLists.getRunSize(), latestRun);
             System.out.println("Your latest run:");
             System.out.println(WorkoutConstant.RUN_HEADER_INDEX_FORMAT);

--- a/src/main/java/ui/Output.java
+++ b/src/main/java/ui/Output.java
@@ -10,7 +10,7 @@ import workouts.Gym;
 import workouts.GymStation;
 import workouts.Run;
 import workouts.Workout;
-import workouts.WorkoutList;
+import workouts.WorkoutLists;
 import health.HealthList;
 import health.Bmi;
 import health.Period;
@@ -196,7 +196,7 @@ public class Output {
         System.out.println(WorkoutConstant.HISTORY_WORKOUTS_HEADER);
         System.out.println(WorkoutConstant.HISTORY_WORKOUTS_HEADER_FORMAT);
 
-        ArrayList<? extends Workout> workoutList = WorkoutList.getWorkouts(WorkoutConstant.ALL);
+        ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts(WorkoutConstant.ALL);
         for (int i = 0; i < workoutList.size(); i++) {
             Workout workout = workoutList.get(i);
             if (workout instanceof Run) {
@@ -231,7 +231,7 @@ public class Output {
     protected void printRunHistory() throws CustomExceptions.OutOfBounds, CustomExceptions.InvalidInput {
         printLine();
         System.out.println("Your run history:");
-        ArrayList<? extends Workout> workoutList = WorkoutList.getWorkouts(WorkoutConstant.RUN);
+        ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts(WorkoutConstant.RUN);
         String runHeader = String.format(WorkoutConstant.RUN_HEADER_INDEX_FORMAT);
         System.out.println(runHeader);
 
@@ -265,7 +265,7 @@ public class Output {
     protected void printGymHistory() throws CustomExceptions.OutOfBounds, CustomExceptions.InvalidInput {
         printLine();
         System.out.println("Your gym history:");
-        ArrayList<? extends Workout> workoutList = WorkoutList.getWorkouts(WorkoutConstant.GYM);
+        ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts(WorkoutConstant.GYM);
         for (int i = 0; i < workoutList.size(); i++) {
             int index = i + 1;
             Gym currentWorkout = (Gym) workoutList.get(i);
@@ -342,8 +342,8 @@ public class Output {
 
         try {
             printLine();
-            Workout latestRun = WorkoutList.getLatestRun();
-            String latestRunString = getFormattedRunWithIndex(WorkoutList.getRunSize(), latestRun);
+            Workout latestRun = WorkoutLists.getLatestRun();
+            String latestRunString = getFormattedRunWithIndex(WorkoutLists.getRunSize(), latestRun);
             System.out.println("Your latest run:");
             System.out.println(WorkoutConstant.RUN_HEADER_INDEX_FORMAT);
             System.out.println(latestRunString);
@@ -361,8 +361,8 @@ public class Output {
 
         try {
             printLine();
-            Gym latestGym = WorkoutList.getLatestGym();
-            int index = WorkoutList.getGymSize();
+            Gym latestGym = WorkoutLists.getLatestGym();
+            int index = WorkoutLists.getGymSize();
             System.out.println("Your latest gym:");
             System.out.println("Gym Session " + index + latestGym);
             printGymStats(latestGym);

--- a/src/main/java/ui/Output.java
+++ b/src/main/java/ui/Output.java
@@ -199,8 +199,7 @@ public class Output {
         ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts();
         if (workoutList.isEmpty()) {
             printWorkoutEmptyMessage();
-        }
-        else {
+        } else {
             for (int i = 0; i < workoutList.size(); i++) {
                 Workout workout = workoutList.get(i);
                 if (workout instanceof Run) {
@@ -579,5 +578,24 @@ public class Output {
         System.out.println("PulsePilot successful touchdown");
         System.out.println("See you soon, Captain!");
         printLine();
+    }
+
+    // Print Delete Message
+
+    public static void printDeleteRunMessage(Run run){
+        printLine();
+        String messageString = String.format(WorkoutConstant.RUN_DELETE_MESSAGE_FORMAT,
+                run.getDistance(),
+                run.getPace());
+        System.out.println(messageString);
+        printLine();
+    }
+
+    public static void printDeleteGymMessage(Gym gym){
+        Output.printLine();
+        String messageString = String.format(WorkoutConstant.GYM_DELETE_MESSAGE_FORMAT,
+                gym.getStations().size());
+        System.out.println(messageString);
+        Output.printLine();
     }
 }

--- a/src/main/java/utility/Validation.java
+++ b/src/main/java/utility/Validation.java
@@ -595,4 +595,21 @@ public class Validation {
             }
         }
     }
+
+    /**
+     * Validates whether the current index provided is within the start and end
+     *
+     * @param index the index to be validated
+     * @param start the starting bound
+     * @param end the ending bound (exclusive - e.g. end = 5 means index must be < 5)
+     * @return true if the index is within the bounds, false otherwise
+     */
+    public static boolean validateIndexWithinBounds(int index, int start, int end)
+            throws CustomExceptions.OutOfBounds {
+
+        if (index < start || index >= end){
+            throw new CustomExceptions.OutOfBounds(ErrorConstant.INVALID_INDEX_BOUND_ERROR);
+        }
+        return true;
+    }
 }

--- a/src/main/java/workouts/Gym.java
+++ b/src/main/java/workouts/Gym.java
@@ -17,12 +17,12 @@ public class Gym extends Workout {
     protected LocalDate date = null;
     protected ArrayList<GymStation> stations = new ArrayList<>();
     private final Parser parser = new Parser();
-    private final WorkoutList workoutList = new WorkoutList();
+    private final WorkoutLists workoutLists = new WorkoutLists();
     /**
      * Constructor that adds a Gym object to WorkoutList.
      */
     public Gym() {
-        workoutList.addGym(this);
+        workoutLists.addGym(this);
     }
 
     /**
@@ -32,7 +32,7 @@ public class Gym extends Workout {
      */
     public Gym(String stringDate) {
         this.date = parser.parseDate(stringDate);
-        workoutList.addGym(this);
+        workoutLists.addGym(this);
     }
 
     /**

--- a/src/main/java/workouts/Gym.java
+++ b/src/main/java/workouts/Gym.java
@@ -1,12 +1,9 @@
 package workouts;
 
 import utility.CustomExceptions;
-import constants.ErrorConstant;
-import utility.Parser;
 import constants.UiConstant;
 import constants.WorkoutConstant;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 
 /**
@@ -14,15 +11,12 @@ import java.util.ArrayList;
  */
 public class Gym extends Workout {
     //@@author JustinSoh
-    protected LocalDate date = null;
+
     protected ArrayList<GymStation> stations = new ArrayList<>();
-    private final Parser parser = new Parser();
-    private final WorkoutLists workoutLists = new WorkoutLists();
     /**
      * Constructor that adds a Gym object to WorkoutList.
      */
     public Gym() {
-        workoutLists.addGym(this);
     }
 
     /**
@@ -31,8 +25,7 @@ public class Gym extends Workout {
      * @param stringDate String representing the date parameter specified.
      */
     public Gym(String stringDate) {
-        this.date = parser.parseDate(stringDate);
-        workoutLists.addGym(this);
+        super(stringDate);
     }
 
     /**
@@ -64,10 +57,6 @@ public class Gym extends Workout {
         return stations;
     }
 
-    private void appendIntoStations(GymStation station) {
-        stations.add(station);
-    }
-
     public GymStation getStationByIndex(int index) throws CustomExceptions.OutOfBounds {
         if (index >= stations.size() || index < 0) {
             throw new CustomExceptions.OutOfBounds(WorkoutConstant.INVALID_GYM_STATION_INDEX);
@@ -75,30 +64,15 @@ public class Gym extends Workout {
         return stations.get(index);
     }
 
-
-    @Override
-    public LocalDate getDate() {
-        return date;
-    }
-
-    public void setDate(LocalDate date) {
-        this.date = date;
-    }
-
     /**
      * Retrieves the string representation of a Gym object.
      *
      * @return A formatted string representing the Gym object, inclusive of the date and gym stations done.
      */
+
     @Override
     public String toString() {
-        String printedDate;
-        if (date != null) {
-            printedDate = date.toString();
-            return String.format(" (Date: %s)", printedDate);
-        } else {
-            return " (Date: NA)";
-        }
+        return String.format(" (Date: %s)", super.getDate());
     }
 
 
@@ -112,13 +86,7 @@ public class Gym extends Workout {
         StringBuilder fileString = new StringBuilder();
         String type = WorkoutConstant.GYM.toUpperCase();
         String numOfStation = String.valueOf(stations.size());
-        String date;
-        if(this.getDate() == null){
-            date = ErrorConstant.NO_DATE_SPECIFIED_ERROR;
-        } else {
-            date = parser.parseFormattedDate(this.getDate());
-        }
-
+        String date = super.getDateForFile();
         fileString.append(type);
         fileString.append(UiConstant.SPLIT_BY_COLON);
         fileString.append(numOfStation);
@@ -158,12 +126,7 @@ public class Gym extends Workout {
      */
     public String getHistoryFormatForSpecificGymStation(int index) {
 
-        StringBuilder gymDate = new StringBuilder();
-        if (date != null) {
-            gymDate.append(date);
-        } else {
-            gymDate.append(ErrorConstant.NO_DATE_SPECIFIED_ERROR);
-        }
+        String gymDate = super.getDate();
 
         // Get the string format for a specific gym station
         GymStation station = getStations().get(index);
@@ -190,5 +153,13 @@ public class Gym extends Workout {
 
         }
     }
+
+    // Private methods
+
+
+    private void appendIntoStations(GymStation station) {
+        stations.add(station);
+    }
+
 
 }

--- a/src/main/java/workouts/Run.java
+++ b/src/main/java/workouts/Run.java
@@ -1,25 +1,23 @@
 package workouts;
 
-import java.time.LocalDate;
 
 import utility.CustomExceptions;
-import utility.Parser;
 import constants.ErrorConstant;
 import constants.UiConstant;
 import constants.WorkoutConstant;
 
 /**
- * Represents a Run object.
+ * Represents a Run object that extends the Workout class.
+ * It takes in the {@code time} and {@code distance} of the run as input.
+ * It also calculates the pace of the run based on the time and distance.
+ * It also formats the time and distance into a readable format.
  */
 public class Run extends Workout {
     //@@author rouvinerh
-    protected Integer[] times;
-    protected double distance;
-    protected LocalDate date = null;
-    protected String pace;
-    protected boolean isHourPresent;
-    private final Parser parser = new Parser();
-    private final WorkoutLists workoutLists = new WorkoutLists();
+    private final Integer[] times;
+    private final double distance;
+    private final String pace;
+    private boolean isHourPresent;
 
 
     /**
@@ -33,7 +31,6 @@ public class Run extends Workout {
         times = splitRunTime(stringTime);
         distance = Double.parseDouble(stringDistance);
         pace = calculatePace();
-        workoutLists.addRun(this);
     }
 
     /**
@@ -45,34 +42,35 @@ public class Run extends Workout {
      * @throws CustomExceptions.InvalidInput If there is invalid input.
      */
     public Run(String stringTime, String stringDistance, String stringDate) throws CustomExceptions.InvalidInput {
+        super(stringDate);
         times = splitRunTime(stringTime);
         distance = Double.parseDouble(stringDistance);
-        date = parser.parseDate(stringDate);
         pace = calculatePace();
-        workoutLists.addRun(this);
     }
 
     /**
-     * Returns string format of time taken for run.
+     * Returns string format of time taken for run depending on {@code isHourPresent}
+     * If there isn't an hour present, returns only mm:ss
+     * If not returns hh:mm:ss
      *
      * @return Formatted string of the time for the run.
      */
     public String getTimes() {
-        if (isHourPresent) {
-            return String.format(WorkoutConstant.TWO_DIGIT_PLACE_FORMAT, times[0])
-                    + ":"
-                    + String.format(WorkoutConstant.TWO_DIGIT_PLACE_FORMAT, times[1])
-                    + ":"
-                    + String.format(WorkoutConstant.TWO_DIGIT_PLACE_FORMAT, times[2]);
+        if (isHourPresent()) {
+            int hours = times[WorkoutConstant.RUN_TIME_FIRST_PART];
+            int minutes = times[WorkoutConstant.RUN_TIME_SECOND_PART];
+            int seconds = times[WorkoutConstant.RUN_TIME_THIRD_PART];
+            return String.format(WorkoutConstant.TIME_WITH_HOURS_FORMAT, hours, minutes, seconds);
+
         } else {
-            return String.format(WorkoutConstant.TWO_DIGIT_PLACE_FORMAT, times[0])
-                    + ":"
-                    + String.format(WorkoutConstant.TWO_DIGIT_PLACE_FORMAT, times[1]);
+            int minutes = times[WorkoutConstant.RUN_TIME_FIRST_PART];
+            int seconds = times[WorkoutConstant.RUN_TIME_SECOND_PART];
+            return String.format(WorkoutConstant.TIME_WITHOUT_HOURS_FORMAT, minutes, seconds);
         }
     }
 
     /**
-     * Retrieves run distance.
+     * Retrieves the run distance in two decimal format.
      *
      * @return Run distance.
      */
@@ -88,14 +86,59 @@ public class Run extends Workout {
         return pace;
     }
 
-    @Override
-    public LocalDate getDate() {
-        return date;
+    /**
+     * Returns true if hours are present in the time taken for the run.
+     *
+     * @return true if hours are present, false otherwise.
+     */
+    public boolean isHourPresent() {
+        return isHourPresent;
     }
 
-    public void setDate(LocalDate date) {
-        this.date = date;
+    /**
+     * Sets the boolean variable {@code isHourPresent} to true if hours are present in the time taken for the run.
+     * This is set in the {@code splitRunTime()} method which is called during the construction of the Run object.
+     *
+     * @param hourPresent boolean variable representing if hours are present in the time taken for the run.
+     */
+    public void setHourPresent(boolean hourPresent) {
+        isHourPresent = hourPresent;
     }
+
+    //@@author JustinSoh
+
+    /**
+     * Retrieves the string representation of a Run object.
+     *
+     * @return A formatted string representing a Run object.
+     */
+    @Override
+    public String toString() {
+        String printedDate = super.getDate();
+        return String.format(WorkoutConstant.RUN_DATA_FORMAT, WorkoutConstant.RUN,
+                getTimes(), getDistance(), getPace(), printedDate);
+    }
+
+    /**
+     * Retrieves the string representation of a Run object when printing all history.
+     * Uses {@code WorkoutConstant.HISTORY_WORKOUTS_DATA_FORMAT} to format the string.
+     * Ensures that the format of the string is consistent when printing gym and run objects.
+     * @return a formatted string representing a Run object.
+     */
+    public String getFormatForAllHistory() {
+        String printedDate = super.getDate();
+        return String.format(WorkoutConstant.HISTORY_WORKOUTS_DATA_FORMAT,
+                WorkoutConstant.RUN,
+                printedDate,
+                getDistance(),
+                getTimes(),
+                getPace()
+        );
+
+    }
+
+    //@@author rouvinerh
+    // Protected Methods
 
     /**
      * Method parses the time format in either hh:mm:ss or mm:ss.
@@ -104,44 +147,27 @@ public class Run extends Workout {
      *
      * @param inputTime String variable representing time taken in either hh:mm:ss or mm:ss format
      * @return A list of integers representing the hours (if present), minutes and seconds.
+     * @throws CustomExceptions.InvalidInput if the input time is not in the correct format.
      */
-    public Integer[] splitRunTime(String inputTime) throws CustomExceptions.InvalidInput {
+    protected Integer[] splitRunTime(String inputTime) throws CustomExceptions.InvalidInput {
 
-        String[] stringTimeParts = inputTime.split(":");
+        String[] stringTimeParts = inputTime.split(WorkoutConstant.COLON);
         int inputLength = stringTimeParts.length;
         Integer[] integerTimes = new Integer[inputLength];
 
         if (inputLength == UiConstant.MAX_RUNTIME_ARRAY_LENGTH) {
-            this.isHourPresent = true;
-            integerTimes[0] = Integer.parseInt(stringTimeParts[0]);
-            integerTimes[1] = Integer.parseInt(stringTimeParts[1]);
-            integerTimes[2] = Integer.parseInt(stringTimeParts[2]);
+            setHourPresent(true);
+            integerTimes[0] = Integer.parseInt(stringTimeParts[WorkoutConstant.RUN_TIME_FIRST_PART]);
+            integerTimes[1] = Integer.parseInt(stringTimeParts[WorkoutConstant.RUN_TIME_SECOND_PART]);
+            integerTimes[2] = Integer.parseInt(stringTimeParts[WorkoutConstant.RUN_TIME_THIRD_PART]);
         } else if (inputLength == UiConstant.MIN_RUNTIME_ARRAY_LENGTH) {
-            this.isHourPresent = false;
-            integerTimes[0] = Integer.parseInt(stringTimeParts[0]);
-            integerTimes[1] = Integer.parseInt(stringTimeParts[1]);
+            setHourPresent(false);
+            integerTimes[0] = Integer.parseInt(stringTimeParts[WorkoutConstant.RUN_TIME_FIRST_PART]);
+            integerTimes[1] = Integer.parseInt(stringTimeParts[WorkoutConstant.RUN_TIME_SECOND_PART]);
         } else {
             throw new CustomExceptions.InvalidInput(WorkoutConstant.INVALID_RUN_TIME);
         }
         return integerTimes;
-    }
-
-    /**
-     * Method checks if hour has been specified, then returns total seconds.
-     *
-     * @return The total number of seconds in the run.
-     */
-    public int calculateTotalSeconds() {
-        int totalSeconds;
-
-        if (this.isHourPresent) {
-            totalSeconds = this.times[0] * UiConstant.NUM_SECONDS_IN_HOUR
-                    + this.times[1] * UiConstant.NUM_SECONDS_IN_MINUTE
-                    + this.times[2];
-        } else {
-            totalSeconds = this.times[0] * UiConstant.NUM_SECONDS_IN_MINUTE + this.times[1];
-        }
-        return totalSeconds;
     }
 
     /**
@@ -151,7 +177,7 @@ public class Run extends Workout {
      * @return Formatted string the pace of the run.
      * @throws CustomExceptions.InvalidInput If the total time taken or pace calculated is too large or small.
      */
-    public String calculatePace() throws CustomExceptions.InvalidInput {
+    protected String calculatePace() throws CustomExceptions.InvalidInput {
         int totalSeconds = calculateTotalSeconds();
         if (totalSeconds <= WorkoutConstant.MIN_RUN_TIME_IN_SECONDS) {
             throw new CustomExceptions.InvalidInput(ErrorConstant.ZERO_RUN_TIME_ERROR);
@@ -173,47 +199,27 @@ public class Run extends Workout {
         int minutes = (int) paceInDecimal;
         double remainingSeconds = paceInDecimal - minutes;
         int seconds = (int) Math.round(remainingSeconds * UiConstant.NUM_SECONDS_IN_MINUTE);
-        return String.format("%d:%02d/km", minutes, seconds);
+
+        return String.format(WorkoutConstant.RUN_PACE_FORMAT, minutes, seconds);
     }
-    //@@author JustinSoh
 
     /**
-     * Retrieves the string representation of a Run object.
+     * Returns the total seconds based on the {@code times} taken for the run.
      *
-     * @return A formatted string representing a Run object.
+     *
+     * @return The total number of seconds in the run.
      */
-    @Override
-    public String toString() {
-        String printedDate;
-        if (date != null) {
-            printedDate = date.toString();
+    protected int calculateTotalSeconds() {
+        int totalSeconds;
+
+        if (isHourPresent()) {
+            totalSeconds = this.times[WorkoutConstant.RUN_TIME_FIRST_PART] * UiConstant.NUM_SECONDS_IN_HOUR
+                    + this.times[WorkoutConstant.RUN_TIME_SECOND_PART] * UiConstant.NUM_SECONDS_IN_MINUTE
+                    + this.times[WorkoutConstant.RUN_TIME_THIRD_PART];
         } else {
-            printedDate = ErrorConstant.NO_DATE_SPECIFIED_ERROR;
+            totalSeconds = this.times[WorkoutConstant.RUN_TIME_FIRST_PART] * UiConstant.NUM_SECONDS_IN_MINUTE
+                    + this.times[WorkoutConstant.RUN_TIME_SECOND_PART];
         }
-        return String.format(WorkoutConstant.RUN_DATA_FORMAT, WorkoutConstant.RUN,
-                getTimes(), getDistance(), getPace(), printedDate);
+        return totalSeconds;
     }
-
-    public String getFormatForAllHistory() {
-        String printedDate;
-
-        if (date != null) {
-            printedDate = date.toString();
-        } else {
-            printedDate = ErrorConstant.NO_DATE_SPECIFIED_ERROR;
-        }
-        return String.format(WorkoutConstant.HISTORY_WORKOUTS_DATA_FORMAT,
-                WorkoutConstant.RUN,
-                printedDate,
-                getDistance(),
-                getTimes(),
-                getPace(),
-                "-", // Placeholder for gym sets (NA)
-                "-", // Placeholder for gym reps (NA)
-                "-", // Placeholder for gym weight (NA)
-                "-"  // Placeholder for gym station (NA)
-        );
-
-    }
-
 }

--- a/src/main/java/workouts/Run.java
+++ b/src/main/java/workouts/Run.java
@@ -19,7 +19,7 @@ public class Run extends Workout {
     protected String pace;
     protected boolean isHourPresent;
     private final Parser parser = new Parser();
-    private final WorkoutList workoutList = new WorkoutList();
+    private final WorkoutLists workoutLists = new WorkoutLists();
 
 
     /**
@@ -33,7 +33,7 @@ public class Run extends Workout {
         times = splitRunTime(stringTime);
         distance = Double.parseDouble(stringDistance);
         pace = calculatePace();
-        workoutList.addRun(this);
+        workoutLists.addRun(this);
     }
 
     /**
@@ -49,7 +49,7 @@ public class Run extends Workout {
         distance = Double.parseDouble(stringDistance);
         date = parser.parseDate(stringDate);
         pace = calculatePace();
-        workoutList.addRun(this);
+        workoutLists.addRun(this);
     }
 
     /**

--- a/src/main/java/workouts/Workout.java
+++ b/src/main/java/workouts/Workout.java
@@ -1,14 +1,19 @@
 package workouts;
 import java.time.LocalDate;
+
+import constants.ErrorConstant;
 import utility.Parser;
 
 /**
- * Represents a Workout object for PulsePilot.
+ * Workout class is a parent class that is used in Gym and Run classes.
+ * It contains the date of the workout and a parser object to parse the date.
  */
 public class Workout {
     //@@author JustinSoh
-    protected LocalDate date = null;
-    private Parser parser;
+    private LocalDate date = null;
+    private final Parser parser;
+    private final WorkoutLists workoutLists;
+
 
     /**
      * Overloaded constructor that uses the optional date parameter from user input.
@@ -17,7 +22,9 @@ public class Workout {
      */
     public Workout(String stringDate) {
         parser = new Parser();
+        workoutLists = new WorkoutLists();
         this.date = parser.parseDate(stringDate);
+        addIntoWorkoutList(this);
     }
 
     /**
@@ -25,17 +32,44 @@ public class Workout {
      */
     public Workout() {
         parser = new Parser();
+        workoutLists = new WorkoutLists();
+        addIntoWorkoutList(this);
+    }
+
+
+    /**
+     * Returns the date of the workout. If the date is not specified (null)
+     * It will return {@code ErrorConstant.NO_DATE_SPECIFIED_ERROR} as the dateString.
+     *
+     * @return validatedDate as a string representing the date of the workout.
+     */
+    public String getDate() {
+        String validatedDate = "";
+        if(this.date == null){
+            validatedDate = ErrorConstant.NO_DATE_SPECIFIED_ERROR;
+        } else {
+            validatedDate = this.date.toString();
+        }
+
+        return validatedDate;
+    }
+
+    public String getDateForFile(){
+        return parser.parseFormattedDate(this.date);
     }
 
     /**
-     * Returns the date of the workout.
+     * Adds the workout object into the workout list.
      *
-     * @return LocalDate variable representing the date of the workout.
+     * @param workout The workout object to be added.
      */
-    public LocalDate getDate() {
-        return date;
+    private void addIntoWorkoutList(Workout workout) {
+        if (workout instanceof Run) {
+            workoutLists.addRun((Run) workout);
+        } else if (workout instanceof Gym) {
+            workoutLists.addGym((Gym) workout);
+        }
     }
-
 
     /**
      * Retrieves the string representation of a Workout object.

--- a/src/main/java/workouts/WorkoutLists.java
+++ b/src/main/java/workouts/WorkoutLists.java
@@ -11,13 +11,13 @@ import java.util.ArrayList;
 /**
  * Represents the WorkoutList object.
  */
-public class WorkoutList  {
+public class WorkoutLists {
     //@@author JustinSoh
     private static final ArrayList<Workout> WORKOUTS = new ArrayList<>();
     private static final ArrayList<Run> RUNS = new ArrayList<>();
     private static final ArrayList<Gym> GYMS = new ArrayList<>();
 
-    protected WorkoutList() {
+    protected WorkoutLists() {
 
     }
     /**

--- a/src/main/java/workouts/WorkoutLists.java
+++ b/src/main/java/workouts/WorkoutLists.java
@@ -9,7 +9,10 @@ import constants.WorkoutConstant;
 import java.util.ArrayList;
 
 /**
- * Represents the WorkoutList object.
+ * WorkoutLists class contains a static list of workouts, runs and gyms.
+ * You cannot add a new object to the list directly
+ * It will automatically be added when you create a new Run/Gym object.
+ * To retrieve the list of workouts/gym/run, you can use the static 'get' methods provided.
  */
 public class WorkoutLists {
     //@@author JustinSoh
@@ -49,48 +52,18 @@ public class WorkoutLists {
         addWorkout(gym);
     }
 
-    public static ArrayList<Workout> getWorkouts(){
+    public static ArrayList<Workout> getWorkouts() {
         return WORKOUTS;
     }
 
-    /**
-     * Returns a list of workouts based on the filter.
-     *
-     * @param filter can be "all", "run" or "gym".
-     *               "all" returns all workouts.
-     *               "run" returns only runs.
-     *               "gym" returns only gym workouts.
-     * @return ArrayList of workouts.
-     */
-    public static ArrayList<? extends Workout> getWorkouts(String filter)
-            throws CustomExceptions.OutOfBounds,
-            CustomExceptions.InvalidInput {
-
-        filter = filter.toLowerCase();
-
-        if(!filter.equals(WorkoutConstant.ALL) && !filter.equals(WorkoutConstant.RUN)
-                && !filter.equals(WorkoutConstant.GYM)) {
-            throw new CustomExceptions.InvalidInput(ErrorConstant.INSUFFICIENT_HISTORY_FILTER_ERROR);
-        }
-        if(filter.equals(WorkoutConstant.RUN) && RUNS.isEmpty()){
-            throw new CustomExceptions.OutOfBounds(ErrorConstant.RUN_EMPTY_ERROR);
-        }
-        if(filter.equals(WorkoutConstant.ALL) && WORKOUTS.isEmpty()){
-            throw new CustomExceptions.OutOfBounds(ErrorConstant.WORKOUTS_EMPTY_ERROR);
-        }
-        if(filter.equals(WorkoutConstant.GYM) && GYMS.isEmpty()){
-            throw new CustomExceptions.OutOfBounds(ErrorConstant.GYM_EMPTY_ERROR);
-        }
-
-        if(filter.equals(WorkoutConstant.RUN)){
-            return RUNS;
-        } else if (filter.equals(WorkoutConstant.GYM)) {
-            return GYMS;
-        } else {
-            return WORKOUTS;
-        }
-
+    public static ArrayList<Run> getRuns(){
+        return RUNS;
     }
+
+    public static ArrayList<Gym> getGyms() {
+        return GYMS;
+    }
+
 
     /**
      * Returns latest run.
@@ -111,6 +84,47 @@ public class WorkoutLists {
         }
         return GYMS.get(GYMS.size() - 1);
     }
+
+//    /**
+//     * Returns a list of workouts based on the filter.
+//     *
+//     * @param filter can be "all", "run" or "gym".
+//     *               "all" returns all workouts.
+//     *               "run" returns only runs.
+//     *               "gym" returns only gym workouts.
+//     * @return ArrayList of workouts.
+//     */
+////    public static ArrayList<? extends Workout> getWorkouts(String filter)
+////            throws CustomExceptions.OutOfBounds,
+////            CustomExceptions.InvalidInput {
+////
+////        filter = filter.toLowerCase();
+////
+////        if(!filter.equals(WorkoutConstant.ALL) && !filter.equals(WorkoutConstant.RUN)
+////                && !filter.equals(WorkoutConstant.GYM)) {
+////            throw new CustomExceptions.InvalidInput(ErrorConstant.INSUFFICIENT_HISTORY_FILTER_ERROR);
+////        }
+////        if(filter.equals(WorkoutConstant.RUN) && RUNS.isEmpty()){
+////            throw new CustomExceptions.OutOfBounds(ErrorConstant.RUN_EMPTY_ERROR);
+////        }
+////        if(filter.equals(WorkoutConstant.ALL) && WORKOUTS.isEmpty()){
+////            throw new CustomExceptions.OutOfBounds(ErrorConstant.WORKOUTS_EMPTY_ERROR);
+////        }
+////        if(filter.equals(WorkoutConstant.GYM) && GYMS.isEmpty()){
+////            throw new CustomExceptions.OutOfBounds(ErrorConstant.GYM_EMPTY_ERROR);
+////        }
+////
+////        if(filter.equals(WorkoutConstant.RUN)){
+////            return getWorkouts();
+////        } else if (filter.equals(WorkoutConstant.GYM)) {
+////            return getGym
+////        } else {
+////            return WORKOUTS;
+////        }
+////
+////    }
+
+
 
     /**
      * Returns the number of runs in the list.

--- a/src/main/java/workouts/WorkoutLists.java
+++ b/src/main/java/workouts/WorkoutLists.java
@@ -4,7 +4,7 @@ import storage.LogFile;
 import ui.Output;
 import utility.CustomExceptions;
 import constants.ErrorConstant;
-import constants.WorkoutConstant;
+import utility.Validation;
 
 import java.util.ArrayList;
 
@@ -23,47 +23,35 @@ public class WorkoutLists {
     protected WorkoutLists() {
 
     }
-    /**
-     * Adds a workout to the list of workouts.
-     *
-     * @param workout Workout object to be added.
-     */
-    protected void addWorkout(Workout workout) {
-        WORKOUTS.add(workout);
-    }
 
     /**
-     * Adds a run to the list of runs and workouts.
+     * Returns the static list of workouts objects which contains both runs and gyms.
+     * It is important to note that the list is not sorted by date (as it is optional)
+     * Rather, it is ordered by when it has been created.
      *
-     * @param run Run object to be added.
+     * @return The list of workouts.
      */
-    protected void addRun(Run run) {
-        RUNS.add(run);
-        addWorkout(run);
-    }
-
-    /**
-     * Adds a gym to the list of gyms and workouts.
-     *
-     * @param gym Gym object to be added.
-     */
-    protected void addGym(Gym gym) {
-        GYMS.add(gym);
-        addWorkout(gym);
-    }
-
     public static ArrayList<Workout> getWorkouts() {
         return WORKOUTS;
     }
 
+    /**
+     * Returns the static list of runs objects.
+     *
+     * @return The list of runs.
+     */
     public static ArrayList<Run> getRuns(){
         return RUNS;
     }
 
+    /**
+     * Returns the static list of gyms objects.
+     *
+     * @return The list of gyms.
+     */
     public static ArrayList<Gym> getGyms() {
         return GYMS;
     }
-
 
     /**
      * Returns latest run.
@@ -78,53 +66,18 @@ public class WorkoutLists {
         return RUNS.get(RUNS.size() - 1);
     }
 
+    /**
+     * Returns latest gym.
+     *
+     * @return The latest Gym object added.
+     * @throws CustomExceptions.OutOfBounds If no gyms are found in the list.
+     */
     public static Gym getLatestGym() throws CustomExceptions.OutOfBounds {
         if (GYMS.isEmpty()) {
             throw new CustomExceptions.OutOfBounds(ErrorConstant.GYM_EMPTY_ERROR);
         }
         return GYMS.get(GYMS.size() - 1);
     }
-
-//    /**
-//     * Returns a list of workouts based on the filter.
-//     *
-//     * @param filter can be "all", "run" or "gym".
-//     *               "all" returns all workouts.
-//     *               "run" returns only runs.
-//     *               "gym" returns only gym workouts.
-//     * @return ArrayList of workouts.
-//     */
-////    public static ArrayList<? extends Workout> getWorkouts(String filter)
-////            throws CustomExceptions.OutOfBounds,
-////            CustomExceptions.InvalidInput {
-////
-////        filter = filter.toLowerCase();
-////
-////        if(!filter.equals(WorkoutConstant.ALL) && !filter.equals(WorkoutConstant.RUN)
-////                && !filter.equals(WorkoutConstant.GYM)) {
-////            throw new CustomExceptions.InvalidInput(ErrorConstant.INSUFFICIENT_HISTORY_FILTER_ERROR);
-////        }
-////        if(filter.equals(WorkoutConstant.RUN) && RUNS.isEmpty()){
-////            throw new CustomExceptions.OutOfBounds(ErrorConstant.RUN_EMPTY_ERROR);
-////        }
-////        if(filter.equals(WorkoutConstant.ALL) && WORKOUTS.isEmpty()){
-////            throw new CustomExceptions.OutOfBounds(ErrorConstant.WORKOUTS_EMPTY_ERROR);
-////        }
-////        if(filter.equals(WorkoutConstant.GYM) && GYMS.isEmpty()){
-////            throw new CustomExceptions.OutOfBounds(ErrorConstant.GYM_EMPTY_ERROR);
-////        }
-////
-////        if(filter.equals(WorkoutConstant.RUN)){
-////            return getWorkouts();
-////        } else if (filter.equals(WorkoutConstant.GYM)) {
-////            return getGym
-////        } else {
-////            return WORKOUTS;
-////        }
-////
-////    }
-
-
 
     /**
      * Returns the number of runs in the list.
@@ -145,53 +98,83 @@ public class WorkoutLists {
     }
 
     /**
-     * Deletes Gym object based on index.
+     * Deletes Gym object based on the {@code index} that will be validated.
      * @param index Index of the Gym object to be deleted.
+     * @throws CustomExceptions.OutOfBounds If the index is invalid.
      */
     public static void deleteGym(int index) throws CustomExceptions.OutOfBounds {
         assert !GYMS.isEmpty() : "Gym list is empty.";
-        if (index < 0 || index >= GYMS.size()) {
-            throw new CustomExceptions.OutOfBounds("Invalid index to delete!");
+        boolean indexIsValid = Validation.validateIndexWithinBounds(index, 0 , GYMS.size());
+        if (indexIsValid) {
+            Gym deletedGym = GYMS.get(index);
+            Output.printDeleteGymMessage(deletedGym);
+            WORKOUTS.remove(deletedGym);
+            GYMS.remove(index);
+            LogFile.writeLog("Removed gym with index: " + index, false);
         }
-        Gym deletedGym = GYMS.get(index);
-        Output.printLine();
-        System.out.println("Removed Gym entry with " +
-                deletedGym.stations.size() +
-                " stations.");
-        Output.printLine();
-        WORKOUTS.remove(deletedGym);
-        GYMS.remove(index);
-        LogFile.writeLog("Removed gym with index: " + index, false);
     }
 
     /**
-     * Deletes Run object based on index.
+     * Deletes Run object based on the {@code index} that will be validated
      * @param index Index of the Run object to be deleted.
+     * @throws CustomExceptions.OutOfBounds If the index is invalid.
      */
     public static void deleteRun(int index) throws CustomExceptions.OutOfBounds {
         assert !RUNS.isEmpty() : "Run list is empty.";
-        if (index < 0 || index >= RUNS.size()) {
-            throw new CustomExceptions.OutOfBounds("Invalid index to delete!");
+        boolean indexIsValid = Validation.validateIndexWithinBounds(index, 0 , RUNS.size());
+        if (indexIsValid) {
+            Run deletedRun = RUNS.get(index);
+            Output.printDeleteRunMessage(deletedRun);
+            WORKOUTS.remove(deletedRun);
+            RUNS.remove(index);
+            LogFile.writeLog("Removed run with index: " + index, false);
         }
-        Run deletedRun = RUNS.get(index);
-        Output.printLine();
-        System.out.println("Removed Run entry with " +
-                deletedRun.distance +
-                "km at " +
-                deletedRun.getPace() +
-                ".");
-        Output.printLine();
-        WORKOUTS.remove(deletedRun);
-        RUNS.remove(index);
-        LogFile.writeLog("Removed run with index: " + index, false);
     }
 
     /**
      * Clears the workouts, runs and gyms ArrayLists.
+     * Used mainly for JUnit testing to clear the list after each test.
      */
     public static void clearWorkoutsRunGym() {
         WORKOUTS.clear();
         RUNS.clear();
         GYMS.clear();
     }
+
+    // Protected Methods
+    /**
+     * Only classes within the workouts package can add a new run to the list of runs.
+     * This is called automatically when a new run object is created in the Run class.
+     * It will also automatically add the run to the workouts list by calling {@code addWorkout}.
+     *
+     * @param run the Run object to be added
+     */
+    protected void addRun(Run run) {
+        RUNS.add(run);
+        addWorkout(run);
+    }
+
+    /**
+     * Only classes within the workouts package can add a new gym to the list of gyms.
+     * This is called automatically when a new gym object is created in the Gym class.
+     * It will also automatically add the gym to the workouts list by calling {@code addWorkout}.
+     *
+     * @param gym the Gym object to be added.
+     */
+    protected void addGym(Gym gym) {
+        GYMS.add(gym);
+        addWorkout(gym);
+    }
+
+    // Private Methods
+
+    /**
+     * Automatically adds a workout to the list of workouts.
+     *
+     * @param workout Workout object to be added to the {@code WORKOUTS} lists.
+     */
+    private void addWorkout(Workout workout) {
+        WORKOUTS.add(workout);
+    }
+
 }

--- a/src/test/java/storage/DataFileTest.java
+++ b/src/test/java/storage/DataFileTest.java
@@ -12,7 +12,7 @@ import utility.CustomExceptions;
 import workouts.Gym;
 import workouts.Run;
 import workouts.Workout;
-import workouts.WorkoutList;
+import workouts.WorkoutLists;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -59,7 +59,7 @@ public class DataFileTest {
     }
 
     private void cleanup(){
-        WorkoutList.clearWorkoutsRunGym();
+        WorkoutLists.clearWorkoutsRunGym();
         HealthList.clearHealthLists();
     }
     private void assertDataFileContents(String name, ArrayList<Bmi> bmiArrayList,
@@ -296,7 +296,7 @@ public class DataFileTest {
         assertEquals(Arrays.toString(periodArrayList.toArray()),
                 Arrays.toString(HealthList.getPeriods().toArray()));
         assertEquals(Arrays.toString(workoutArrayList.toArray()),
-                Arrays.toString(WorkoutList.getWorkouts().toArray()));
+                Arrays.toString(WorkoutLists.getWorkouts().toArray()));
     }
 
     /**

--- a/src/test/java/ui/HandlerTest.java
+++ b/src/test/java/ui/HandlerTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import constants.ErrorConstant;
-import workouts.WorkoutList;
+import workouts.WorkoutLists;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ByteArrayInputStream;
@@ -36,7 +36,7 @@ class HandlerTest {
         System.setOut(originalOut);
         System.setIn(originalIn);
         System.setErr(originalErr);
-        WorkoutList.clearWorkoutsRunGym();
+        WorkoutLists.clearWorkoutsRunGym();
         HealthList.clearHealthLists();
     }
 

--- a/src/test/java/ui/IntegrationTest.java
+++ b/src/test/java/ui/IntegrationTest.java
@@ -9,7 +9,7 @@ import utility.CustomExceptions;
 import utility.Parser;
 import workouts.Gym;
 import workouts.Run;
-import workouts.WorkoutList;
+import workouts.WorkoutLists;
 import helper.TestHelper;
 
 import java.io.ByteArrayInputStream;
@@ -48,7 +48,7 @@ public class IntegrationTest {
 
     @AfterEach
     public void tearDown(){
-        WorkoutList.clearWorkoutsRunGym();
+        WorkoutLists.clearWorkoutsRunGym();
         HealthList.clearHealthLists();
         outContent.reset();
         errContent.reset();

--- a/src/test/java/ui/OutputTest.java
+++ b/src/test/java/ui/OutputTest.java
@@ -144,19 +144,19 @@ class OutputTest {
 
         // printing latest of an empty run list
         output.printHistory(WorkoutConstant.RUN);
-        expectedString = TestHelper.errorOutOfBoundsString(ErrorConstant.RUN_EMPTY_ERROR);
-        assertTrue(errContent.toString().contains(expectedString));
+        expectedString = TestHelper.errorInvalidCommandString(ErrorConstant.RUN_EMPTY_ERROR);
+        assertEquals(errContent.toString(), expectedString);
         cleanup();
 
         // printing latest of an empty gym list
         output.printHistory(WorkoutConstant.GYM);
-        expectedString = TestHelper.errorOutOfBoundsString(ErrorConstant.GYM_EMPTY_ERROR);
+        expectedString = TestHelper.errorInvalidCommandString(ErrorConstant.GYM_EMPTY_ERROR);
         assertTrue(errContent.toString().contains(expectedString));
         cleanup();
 
         // printing latest of an empty workout list
         output.printHistory(WorkoutConstant.ALL);
-        expectedString = TestHelper.errorOutOfBoundsString(ErrorConstant.WORKOUTS_EMPTY_ERROR);
+        expectedString = TestHelper.errorInvalidCommandString(ErrorConstant.WORKOUTS_EMPTY_ERROR);
         assertTrue(errContent.toString().contains(expectedString));
         cleanup();
 

--- a/src/test/java/ui/OutputTest.java
+++ b/src/test/java/ui/OutputTest.java
@@ -17,7 +17,7 @@ import utility.CustomExceptions;
 import constants.WorkoutConstant;
 import workouts.Gym;
 import workouts.Run;
-import workouts.WorkoutList;
+import workouts.WorkoutLists;
 import health.Bmi;
 import health.Period;
 import health.HealthList;
@@ -51,7 +51,7 @@ class OutputTest {
 
     @AfterEach
     public void cleanup() {
-        WorkoutList.clearWorkoutsRunGym();
+        WorkoutLists.clearWorkoutsRunGym();
         HealthList.clearHealthLists();
         outContent.reset();
         errContent.reset();

--- a/src/test/java/utility/ParserTest.java
+++ b/src/test/java/utility/ParserTest.java
@@ -381,8 +381,8 @@ class ParserTest {
             // make sure that there is two gym station created
             assertEquals(2, gymOutput.getStations().size());
             // make sure that the date is correct
-            assertEquals("1997-11-11", gymOutput.getDate().toString());
-            assertNull(gymOutput2.getDate());
+            assertEquals("1997-11-11", gymOutput.getDate());
+            assertEquals(gymOutput2.getDate(), "NA");
             // make sure the gym exercise names are correct
             assertEquals("bench press", gymOutput.getStationByIndex(0).getStationName());
             assertEquals("squats", gymOutput.getStationByIndex(1).getStationName());

--- a/src/test/java/utility/ValidationTest.java
+++ b/src/test/java/utility/ValidationTest.java
@@ -6,7 +6,7 @@ import health.HealthList;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import workouts.WorkoutList;
+import workouts.WorkoutLists;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -42,7 +42,7 @@ public class ValidationTest {
         System.setOut(originalOut);
         System.setIn(originalIn);
         System.setErr(originalErr);
-        WorkoutList.clearWorkoutsRunGym();
+        WorkoutLists.clearWorkoutsRunGym();
         HealthList.clearHealthLists();
     }
 

--- a/src/test/java/workouts/GymTest.java
+++ b/src/test/java/workouts/GymTest.java
@@ -21,7 +21,7 @@ class GymTest {
 
     @AfterEach
     void cleanup() {
-        WorkoutList.clearWorkoutsRunGym();
+        WorkoutLists.clearWorkoutsRunGym();
     }
 
     /**

--- a/src/test/java/workouts/RunTest.java
+++ b/src/test/java/workouts/RunTest.java
@@ -12,7 +12,7 @@ class RunTest {
 
     @AfterEach
     void cleanup() {
-        WorkoutList.clearWorkoutsRunGym();
+        WorkoutLists.clearWorkoutsRunGym();
     }
     /**
      * Tests the behaviour of parsing a time string with hours into an integer array.

--- a/src/test/java/workouts/WorkoutListsTest.java
+++ b/src/test/java/workouts/WorkoutListsTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
-class WorkoutListTest {
+class WorkoutListsTest {
     @BeforeEach
     void setUp() {
 
@@ -21,7 +21,7 @@ class WorkoutListTest {
 
     @AfterEach
     void cleanup() {
-        WorkoutList.clearWorkoutsRunGym();
+        WorkoutLists.clearWorkoutsRunGym();
     }
 
 
@@ -34,11 +34,11 @@ class WorkoutListTest {
         try {
             Run inputRun = new Run("40:10", "10.3", "15-03-2024");
 
-            WorkoutList workoutListInstance = new WorkoutList();
-            workoutListInstance.addRun(inputRun);
+            WorkoutLists workoutListsInstance = new WorkoutLists();
+            workoutListsInstance.addRun(inputRun);
 
-            ArrayList<? extends Workout> runList = WorkoutList.getWorkouts(WorkoutConstant.RUN);
-            ArrayList<? extends Workout> workoutList = WorkoutList.getWorkouts(WorkoutConstant.ALL);
+            ArrayList<? extends Workout> runList = WorkoutLists.getWorkouts(WorkoutConstant.RUN);
+            ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts(WorkoutConstant.ALL);
 
             Workout expectedRun = runList.get(runList.size() - 1);
             Workout expectedWorkout = workoutList.get(runList.size() - 1);
@@ -68,7 +68,7 @@ class WorkoutListTest {
             inputList.add(new Run("30:10", "20.3", "30-03-2023"));
 
 
-            ArrayList<? extends Workout> runList = WorkoutList.getWorkouts(WorkoutConstant.RUN);
+            ArrayList<? extends Workout> runList = WorkoutLists.getWorkouts(WorkoutConstant.RUN);
             for(int i = 0; i < inputList.size(); i++) {
                 Run expected = inputList.get(i);
                 Run actual = (Run) runList.get(i);
@@ -91,7 +91,7 @@ class WorkoutListTest {
         inputList.add(new Run("30:10", "20.3", "30-03-2023"));
 
         assertThrows(CustomExceptions.InvalidInput.class, () -> {
-            ArrayList<? extends Workout> runList = WorkoutList.getWorkouts("invalidFilter");
+            ArrayList<? extends Workout> runList = WorkoutLists.getWorkouts("invalidFilter");
         });
     }
 
@@ -101,8 +101,8 @@ class WorkoutListTest {
      */
     @Test
     void getWorkouts_emptyList_throwOutOfBoundsForRun() {
-        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutList.getWorkouts(WorkoutConstant.GYM));
-        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutList.getWorkouts(WorkoutConstant.RUN));
+        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getWorkouts(WorkoutConstant.GYM));
+        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getWorkouts(WorkoutConstant.RUN));
     }
 
     /**
@@ -111,7 +111,7 @@ class WorkoutListTest {
      */
     @Test
     void getWorkouts_emptyList_throwOutOfBoundsForAll() {
-        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutList.getWorkouts(WorkoutConstant.ALL));
+        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getWorkouts(WorkoutConstant.ALL));
     }
 
     /**
@@ -124,7 +124,7 @@ class WorkoutListTest {
             new Run("20:10", "10.3", "15-03-2024");
             Run secondRun = new Run("20:10", "10.3", "15-03-2024");
 
-            Run actual = WorkoutList.getLatestRun();
+            Run actual = WorkoutLists.getLatestRun();
             assertEquals(secondRun, actual);
         } catch (CustomExceptions.OutOfBounds | CustomExceptions.InvalidInput e) {
             fail("Should not throw an exception");
@@ -138,7 +138,7 @@ class WorkoutListTest {
     @Test
     void getLatestRun_emptyList_throwOutOfBound() {
         // Call the method or code that should throw the exception
-        assertThrows(CustomExceptions.OutOfBounds.class, WorkoutList::getLatestRun);
+        assertThrows(CustomExceptions.OutOfBounds.class, WorkoutLists::getLatestRun);
     }
 
 
@@ -154,8 +154,8 @@ class WorkoutListTest {
         new Run("20:10", "10.3", "15-03-2024");
         new Run("20:11", "10.3", "15-03-2023");
         int index = 1;
-        WorkoutList.deleteRun(index);
-        assertEquals(1, WorkoutList.getRunSize());
+        WorkoutLists.deleteRun(index);
+        assertEquals(1, WorkoutLists.getRunSize());
     }
 
     /**
@@ -165,7 +165,7 @@ class WorkoutListTest {
     @Test
     void deleteRun_emptyList_throwsAssertionError() {
         assertThrows (AssertionError.class, () ->
-                WorkoutList.deleteRun(0));
+                WorkoutLists.deleteRun(0));
     }
 
     /**
@@ -179,7 +179,7 @@ class WorkoutListTest {
         new Run("20:11", "10.3", "15-03-2023");
         int invalidIndex = 5;
         assertThrows (CustomExceptions.OutOfBounds.class, () ->
-                WorkoutList.deleteRun(invalidIndex));
+                WorkoutLists.deleteRun(invalidIndex));
     }
 
     /**
@@ -204,8 +204,8 @@ class WorkoutListTest {
         gym2.addStation("Bicep curls", 1, 10, array1);
 
         int index = 1;
-        WorkoutList.deleteGym(index);
-        assertEquals(1, WorkoutList.getGymSize());
+        WorkoutLists.deleteGym(index);
+        assertEquals(1, WorkoutLists.getGymSize());
     }
 
     /**
@@ -215,7 +215,7 @@ class WorkoutListTest {
     @Test
     void deleteGym_emptyList_throwsAssertionError() {
         assertThrows (AssertionError.class, () ->
-                WorkoutList.deleteGym(0));
+                WorkoutLists.deleteGym(0));
     }
 
     /**
@@ -233,6 +233,6 @@ class WorkoutListTest {
         gym1.addStation("Shoulder Press", 2, 10, array2);
         int invalidIndex = 5;
         assertThrows (CustomExceptions.OutOfBounds.class, () ->
-                WorkoutList.deleteGym(invalidIndex));
+                WorkoutLists.deleteGym(invalidIndex));
     }
 }

--- a/src/test/java/workouts/WorkoutListsTest.java
+++ b/src/test/java/workouts/WorkoutListsTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import utility.CustomExceptions;
-import constants.WorkoutConstant;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,26 +77,6 @@ class WorkoutListsTest {
         }
     }
 
-
-
-//    /**
-//     * Tests the behavior of getting an empty run / gym list
-//     * Expected behaviour is to raise {@code OutOfBounds} exception.
-//     */
-//    @Test
-//    void getWorkouts_emptyList_throwOutOfBoundsForRun() {
-//        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getGyms());
-//        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getRuns());
-//    }
-
-//    /**
-//     * Tests the behavior of getting an empty run list
-//     * Expected behaviour is to raise {@code OutOfBounds} exception.
-//     */
-//    @Test
-//    void getWorkouts_emptyList_throwOutOfBoundsForAll() {
-//        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getWorkouts(WorkoutConstant.ALL));
-//    }
 
     /**
      * Tests the behavior of getting the latest run from the run list.

--- a/src/test/java/workouts/WorkoutListsTest.java
+++ b/src/test/java/workouts/WorkoutListsTest.java
@@ -37,8 +37,8 @@ class WorkoutListsTest {
             WorkoutLists workoutListsInstance = new WorkoutLists();
             workoutListsInstance.addRun(inputRun);
 
-            ArrayList<? extends Workout> runList = WorkoutLists.getWorkouts(WorkoutConstant.RUN);
-            ArrayList<? extends Workout> workoutList = WorkoutLists.getWorkouts(WorkoutConstant.ALL);
+            ArrayList<Run> runList = WorkoutLists.getRuns();
+            ArrayList<Workout> workoutList = WorkoutLists.getWorkouts();
 
             Workout expectedRun = runList.get(runList.size() - 1);
             Workout expectedWorkout = workoutList.get(runList.size() - 1);
@@ -46,8 +46,6 @@ class WorkoutListsTest {
             assertEquals(inputRun, expectedRun);
             assertEquals(inputRun, expectedWorkout);
 
-        } catch (CustomExceptions.OutOfBounds e) {
-            fail("Should not throw an exception");
         } catch (CustomExceptions.InvalidInput e) {
             fail("Should not throw an exception.");
         }
@@ -68,51 +66,38 @@ class WorkoutListsTest {
             inputList.add(new Run("30:10", "20.3", "30-03-2023"));
 
 
-            ArrayList<? extends Workout> runList = WorkoutLists.getWorkouts(WorkoutConstant.RUN);
+            ArrayList<Run> runList = WorkoutLists.getRuns();
             for(int i = 0; i < inputList.size(); i++) {
                 Run expected = inputList.get(i);
                 Run actual = (Run) runList.get(i);
                 assertEquals(expected, actual);
             }
 
-        } catch (CustomExceptions.OutOfBounds | CustomExceptions.InvalidInput e) {
+        } catch (CustomExceptions.InvalidInput e) {
             fail("Should not throw an exception.");
         }
     }
 
-    /**
-     * Tests the behavior of getting the workout list with {@code RUN} , {@code ALL}
-     * Verifies whether the method is able to correct retrieve the list of workouts.
-     */
-    @Test
-    void getWorkouts_improperFilters_throwInvalidInput() throws CustomExceptions.InvalidInput {
-        ArrayList<Workout> inputList = new ArrayList<>();
-        inputList.add(new Run("40:10", "10.3", "15-03-2024"));
-        inputList.add(new Run("30:10", "20.3", "30-03-2023"));
 
-        assertThrows(CustomExceptions.InvalidInput.class, () -> {
-            ArrayList<? extends Workout> runList = WorkoutLists.getWorkouts("invalidFilter");
-        });
-    }
 
-    /**
-     * Tests the behavior of getting an empty run / gym list
-     * Expected behaviour is to raise {@code OutOfBounds} exception.
-     */
-    @Test
-    void getWorkouts_emptyList_throwOutOfBoundsForRun() {
-        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getWorkouts(WorkoutConstant.GYM));
-        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getWorkouts(WorkoutConstant.RUN));
-    }
+//    /**
+//     * Tests the behavior of getting an empty run / gym list
+//     * Expected behaviour is to raise {@code OutOfBounds} exception.
+//     */
+//    @Test
+//    void getWorkouts_emptyList_throwOutOfBoundsForRun() {
+//        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getGyms());
+//        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getRuns());
+//    }
 
-    /**
-     * Tests the behavior of getting an empty run list
-     * Expected behaviour is to raise {@code OutOfBounds} exception.
-     */
-    @Test
-    void getWorkouts_emptyList_throwOutOfBoundsForAll() {
-        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getWorkouts(WorkoutConstant.ALL));
-    }
+//    /**
+//     * Tests the behavior of getting an empty run list
+//     * Expected behaviour is to raise {@code OutOfBounds} exception.
+//     */
+//    @Test
+//    void getWorkouts_emptyList_throwOutOfBoundsForAll() {
+//        assertThrows(CustomExceptions.OutOfBounds.class, () -> WorkoutLists.getWorkouts(WorkoutConstant.ALL));
+//    }
 
     /**
      * Tests the behavior of getting the latest run from the run list.


### PR DESCRIPTION
**Changes made to WorkoutLists**
[X] Rename `WorkoutList` class to `WorkoutLists` as it contains multiple lists 
[X] Removed `getWorkouts(Filter)` and abstracted it into `getRun()`, `getWorkout()`, and `getGym()` for a more OOP-approach 
[X] Created `Output.deleteRunMessage()` and `Output.deleteGymMessage()` to abstract out the printing from workoutLists
[X] Moved index validation in `WorkoutLists.deleteGym(index)`  and `WorkoutLists.deleteRun(index)` to `Validation.validateIndexWithinBounds(int index, int start, int end)` to make it more reusable 
[X] Touched up on JavaDocs

**Changes made to Workout**
[X] Moved the date creation from `Gym` and `Run` to Workout 
[X] Added `Workout.getDateForFile()` which returns the date in `dd-MM-YYYY` format
[X] Added `Workout.getDate` which returns a string of the date in `YYYY-MM-DD` format
[X] Added `addIntoWorkoutList` method which is called in Workout to automatically add `Run` and `Gym` object into Workout List 
[X] Touched up on JavaDocs 

**Changes made to Run** 
[X] Removed magic strings into Constant File 
[X] Changed Variables to private and use getter and setter when accessing them 
[X] Set proper accessing level for methods 
[X] SLAP the code to make it more readable 
[X] Fixed JavaDocs

** Changes made to Gym (incomplete)**
[X] Removed the date assignment in the constructor and instead call super() during object creation



[@L5-Z please take note of the changes made to dates] 
[@rouvinerh not too sure what you meant by changes to run so I didn't implement it] 